### PR TITLE
Improve item handling and connecting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# APWorld files should be built separately
+*.apworld

--- a/apworld/mml/items.py
+++ b/apworld/mml/items.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 ITEM_NAME_TO_ID = {
     "Nothing":                              0x00FF,
     "Power Raiser":                         0x020D,
+    "Buster Max":                           0x0210,
     "Power Stream":                         0x0211,
     "Blaster Unit R":                       0x0212,
     "Buster Unit Omega":                    0x0213,
@@ -96,7 +97,8 @@ ITEM_NAME_TO_ID = {
 #TODO map every item to a classification of progressive,useful,filler,etc
 DEFAULT_ITEM_CLASSIFICATIONS = {
     "Nothing":                              ItemClassification.filler, 
-    "Power Raiser":                         ItemClassification.filler, 
+    "Power Raiser":                         ItemClassification.filler,
+    "Buster Max":                           ItemClassification.useful,
     "Power Stream":                         ItemClassification.filler, 
     "Blaster Unit R":                       ItemClassification.filler, 
     "Buster Unit Omega":                    ItemClassification.filler, 

--- a/source/MMLAP/MMLAP.csproj
+++ b/source/MMLAP/MMLAP.csproj
@@ -14,6 +14,7 @@
 	<!--https://github.com/Uroogla/Archipelago.Core-->
 
   <ItemGroup>
+    <PackageReference Include="Archipelago.Core" Version="1.4.2" />
     <PackageReference Include="Archipelago.Core.AvaloniaGUI" Version="0.6.1" />
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />


### PR DESCRIPTION
- Adds an item (Buster Max) to the datapackage to allow for starting with it, without adding it to the randomized item pool
- Handles Core's exception on trying to connect when Duckstation is not yet open
- Fixed a crash when another game's items are in MML
- Moves game loop logic to start only after the player is in control of Rock
- Updates Core to prevent a crash when items have been queued offline